### PR TITLE
Parameterise build across types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: cpp
 sudo: required
 services:
     - docker
+env:
+    - BUILD_TYPE=RelWithDebInfo
+    - BUILD_TYPE=Release
+    - BUILD_TYPE=Debug
 before_install:
     # Encrypted key setup
     - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
@@ -13,9 +17,7 @@ before_install:
     - docker build -t neon .
 script:
     - docker run -e TRAVIS=$TRAVIS -e TRAVIS_JOB_ID=$TRAVIS_JOB_ID --name neon-docker -d -t neon /bin/bash
-    - docker exec neon-docker /bin/bash -c "mkdir -p neon/build && cd neon/build && cmake -DCMAKE_BUILD_TYPE=Debug .. && make all -j2"
-    - docker exec neon-docker /bin/bash -c "cd neon/build && make install && ctest"
-    - docker exec neon-docker /bin/bash -c "cd neon/build && cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_COVERAGE=TRUE .. && make all -j2"
+    - docker exec neon-docker /bin/bash -c "mkdir -p neon/build && cd neon/build && cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE .. && make all -j2"
     - docker exec neon-docker /bin/bash -c "cd neon/build && make install && ctest"
 after_success:
     # Coverage

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,6 @@ cmake_minimum_required(VERSION 3.9)
 
 project(neonfe VERSION 0.1 LANGUAGES CXX)
 
-message(STATUS "Build type is: " ${CMAKE_BUILD_TYPE})
-
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
 option(ENABLE_CUDA "Enable CUDA linear solver" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ cmake_minimum_required(VERSION 3.9)
 
 project(neonfe VERSION 0.1 LANGUAGES CXX)
 
+message(STATUS "Build type is: " ${CMAKE_BUILD_TYPE})
+
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
 option(ENABLE_CUDA "Enable CUDA linear solver" OFF)
@@ -19,7 +21,7 @@ add_subdirectory(${EXTERNAL_PROJECTS_DIR}/termcolor)
 
 if (ENABLE_CUDA)
     enable_language(CUDA)
-    find_package(CUDA REQUIRED)    
+    find_package(CUDA REQUIRED)
     add_definitions(-DENABLE_CUDA)
 endif()
 


### PR DESCRIPTION
We need to check each build type due to subtle bugs introduced from debug / release modes (largely due to expression templates).  Now we run the builds in parallel.