### PR TITLE
cyclic loading (typo and documentation)

### DIFF
--- a/docs/source/boundary_conditions.rst
+++ b/docs/source/boundary_conditions.rst
@@ -17,9 +17,29 @@ where multiple boundary conditions can be added by inserting extra elements into
 
 The specified time and values are automatically linearly interpolated if a time step happens to fall between two values.  For convenience the adaptive time step algorithm will always produce a solution at the specified time points to easy experimental comparisons.
 
-Since boundary conditions can vary over time, it is possible to specify cyclic type boundary conditions that follow a periodic curve.  This can be specified with ::
+Since boundary conditions can vary over time, it is possible to specify cyclic type boundary conditions that follow a periodic curve.  Currently, only a sinusoidal periodic type is implemented and it can be specified with ::
 
-    "Periodic"
+    "BoundaryConditions" : [{
+        "Name" : "x-sym",
+        "Type" : "Displacement",
+        "GenerateType" : "Sinusoidal",
+        "x" : [0.05, 0.10],
+        "Period" : [10,10],
+        "Phase" : [0,0],
+        "NumberOfCycles" : [2,1]
+    }]
+
+
+This may be used to generate block loading where each block follows a specific sinusoidal wave that corresponds to one entry of ``"x"``, ``"Period"``, ``"Phase"`` and ``"NumberOfCycles"``. In this case the time step is taken to be equal to ::
+
+    "Time" : {
+        "Period" : 30,
+        "Increments" : {
+            "Initial" : 0.1
+        }
+
+and the time steps are generated automatically based on the given boundary condition parameters.
+
 
 Essential (Dirichlet) type
 ==========================

--- a/examples/solid_mechanics/viscoplastic_damage/beam_cyclic/beam.json
+++ b/examples/solid_mechanics/viscoplastic_damage/beam_cyclic/beam.json
@@ -56,7 +56,6 @@
             {
                 "Name" : "x-fixed",
                 "Type" : "Displacement",
-                "Time" : [0.0, 30],
                 "x" : [0.12, 0.10],
                 "GenerateType" : "Sinusoidal",
                 "Period" : [10,10],

--- a/examples/solid_mechanics/viscoplastic_damage/cube_cyclic/cube.json
+++ b/examples/solid_mechanics/viscoplastic_damage/cube_cyclic/cube.json
@@ -66,7 +66,6 @@
             {
                 "Name" : "ZLoad",
 				        "Type" : "Displacement",
-                "Time" : [0.0, 0.01],
                 "z" : [0.001],
                 "GenerateType" : "Sinusoidal",
                 "Period" : [0.01],

--- a/src/mesh/generic/boundary.hpp
+++ b/src/mesh/generic/boundary.hpp
@@ -44,7 +44,8 @@ protected:
     void allocate_time_load(json const& times, json const& loads);
 
     /**
-     * Generate boundary values that follows a sinusoidal wave with fixed time step.
+     * Generate boundary values that follows a sinusoidal wave with fixed time step. This may be
+     * used to generate block loading where each block follows a specific sinusoidal wave.
      * @param JSON boundary object
      * @param dofs {x,y,z}
      * @param time step

--- a/src/mesh/mechanical/beam/fem_mesh.cpp
+++ b/src/mesh/mechanical/beam/fem_mesh.cpp
@@ -149,13 +149,18 @@ void fem_mesh::check_boundary_conditions(json const& boundary_data) const
 {
     for (auto const& boundary : boundary_data)
     {
-        for (auto const& mandatory_field : {"Name", "Time", "Type"})
+        for (auto const& mandatory_field : {"Name", "Type"})
         {
             if (!boundary.count(mandatory_field))
             {
                 throw std::domain_error("\"" + std::string(mandatory_field)
                                         + "\" was not specified in \"BoundaryCondition\".");
             }
+        }
+        if ((!boundary.count("Time")) && (!boundary.count("GenerateType")))
+        {
+            throw std::domain_error("Neither \"Time\" nor \"GenerateType\" was specified in "
+                                    "\"BoundaryCondition\".");
         }
     }
 }

--- a/src/mesh/mechanical/plane/fem_mesh.cpp
+++ b/src/mesh/mechanical/plane/fem_mesh.cpp
@@ -151,13 +151,18 @@ void fem_mesh::check_boundary_conditions(json const& boundary_data) const
 {
     for (auto const& boundary : boundary_data)
     {
-        for (auto const& mandatory_field : {"Name", "Time", "Type"})
+        for (auto const& mandatory_field : {"Name", "Type"})
         {
             if (!boundary.count(mandatory_field))
             {
                 throw std::domain_error("\"" + std::string(mandatory_field)
                                         + "\" was not specified in \"BoundaryCondition\".");
             }
+        }
+        if ((!boundary.count("Time")) && (!boundary.count("GenerateType")))
+        {
+            throw std::domain_error("Neither \"Time\" nor \"GenerateType\" was specified in "
+                                    "\"BoundaryCondition\".");
         }
     }
 }

--- a/src/mesh/mechanical/solid/fem_mesh.cpp
+++ b/src/mesh/mechanical/solid/fem_mesh.cpp
@@ -149,13 +149,18 @@ void fem_mesh::check_boundary_conditions(json const& boundary_data) const
 {
     for (auto const& boundary : boundary_data)
     {
-        for (auto const& mandatory_field : {"Name", "Time", "Type"})
+        for (auto const& mandatory_field : {"Name", "Type"})
         {
             if (!boundary.count(mandatory_field))
             {
                 throw std::domain_error("\"" + std::string(mandatory_field)
                                         + "\" was not specified in \"BoundaryCondition\".");
             }
+        }
+        if ((!boundary.count("Time")) && (!boundary.count("GenerateType")))
+        {
+            throw std::domain_error("Neither \"Time\" nor \"GenerateType\" was specified in "
+                                    "\"BoundaryCondition\".");
         }
     }
 }


### PR DESCRIPTION
This fixes a typo in `boundary.cpp` and adds the documentation for cyclic loading boundary conditions.

For cyclic type boundary conditions, there's no need to specify ``Time`` as long as it'll be an outcome of the specified ``NumberOfCycles`` and the time step.

If you don't like the modifications in `fem_mesh.cpp`, I could also check if the `GenerateType` is `Sinusoidal` before deciding that there's no problem with the input.