### PR TITLE
Fix compilation errors in clang

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,7 +11,7 @@ target_compile_options(neon PUBLIC $<$<CONFIG:RELEASE>:-O3>)
 set_target_properties(neon PROPERTIES CXX_STANDARD 17
                                       CXX_STANDARD_REQUIRED YES
                                       CXX_EXTENSIONS NO
-                           COMPILE_FLAGS "-Wall -Wduplicated-cond -Werror"
+                           COMPILE_FLAGS "-Wall -Werror"
                            LINK_FLAGS "-fprofile-arcs")
 
 if (ENABLE_LTO)

--- a/src/constitutive/constitutive_model.hpp
+++ b/src/constitutive/constitutive_model.hpp
@@ -27,6 +27,8 @@ public:
     {
     }
 
+    virtual ~constitutive_model() = default;
+
     /// Update required internal variables and tangent matrix at quadrature points
     /// \param time_step_size Time step size (or load increment if quasi-static)
     virtual void update_internal_variables(double const time_step_size) = 0;

--- a/src/constitutive/mechanical/beam/isotropic_linear.cpp
+++ b/src/constitutive/mechanical/beam/isotropic_linear.cpp
@@ -21,21 +21,18 @@ isotropic_linear::isotropic_linear(std::shared_ptr<variable_type>& variables,
 void isotropic_linear::update_internal_variables()
 {
     // Stiffness components
-    auto [D_b, D_s] = variables->get(variable::second::bending_stiffness,
-                                     variable::second::shear_stiffness);
-
-    auto [D_a, D_t] = variables->get(variable::scalar::axial_stiffness,
-                                     variable::scalar::torsional_stiffness);
+    auto& D_b = variables->get(variable::second::bending_stiffness);
+    auto& D_s = variables->get(variable::second::shear_stiffness);
+    auto& D_a = variables->get(variable::scalar::axial_stiffness);
+    auto& D_t = variables->get(variable::scalar::torsional_stiffness);
 
     // Access the geometric properties at the quadrature points
-    auto [shear_area_1,
-          shear_area_2,
-          cross_sectional_area] = variables->get(variable::scalar::shear_area_1,
-                                                 variable::scalar::shear_area_2,
-                                                 variable::scalar::cross_sectional_area);
-    auto [second_moment_area_1,
-          second_moment_area_2] = variables->get(variable::scalar::second_moment_area_1,
-                                                 variable::scalar::second_moment_area_2);
+    auto& shear_area_1 = variables->get(variable::scalar::shear_area_1);
+    auto& shear_area_2 = variables->get(variable::scalar::shear_area_2);
+    auto& cross_sectional_area = variables->get(variable::scalar::cross_sectional_area);
+
+    auto& second_moment_area_1 = variables->get(variable::scalar::second_moment_area_1);
+    auto& second_moment_area_2 = variables->get(variable::scalar::second_moment_area_2);
 
     tbb::parallel_for(std::size_t{}, variables->entries(), [&](auto const l) {
         // Polar moment of area

--- a/src/constitutive/mechanical/plane/isotropic_linear_elasticity.cpp
+++ b/src/constitutive/mechanical/plane/isotropic_linear_elasticity.cpp
@@ -16,8 +16,7 @@ isotropic_linear_elasticity::isotropic_linear_elasticity(std::shared_ptr<interna
                                                          plane const state)
     : constitutive_model(variables), material(material_data), state(state)
 {
-    variables->add(variable::second::linearised_strain,
-                   variable::scalar::von_mises_stress);
+    variables->add(variable::second::linearised_strain, variable::scalar::von_mises_stress);
 
     names.emplace("linearised_strain");
     names.emplace("von_mises_stress");
@@ -35,9 +34,8 @@ void isotropic_linear_elasticity::update_internal_variables(double const time_st
     // std::cout << "Performing the internal variable updates" << std::endl;
 
     // Extract the internal variables
-    auto [elastic_strains,
-          cauchy_stresses] = variables->get(variable::second::linearised_strain,
-                                            variable::second::cauchy_stress);
+    auto [elastic_strains, cauchy_stresses] = variables->get(variable::second::linearised_strain,
+                                                             variable::second::cauchy_stress);
 
     auto& von_mises_stresses = variables->get(variable::scalar::von_mises_stress);
 
@@ -55,7 +53,7 @@ void isotropic_linear_elasticity::update_internal_variables(double const time_st
     }
 
     // Compute Cauchy stress from the linear elastic strains
-    cauchy_stresses = view::zip(tangents, elastic_strains) | view::transform([this](auto const& tpl) {
+    cauchy_stresses = view::zip(tangents, elastic_strains) | view::transform([](auto const& tpl) {
                           auto const& [C, elastic_strain] = tpl;
                           return voigt::kinetic::from(C * voigt::kinematic::to(elastic_strain));
                       });

--- a/src/constitutive/mechanical/plane/small_strain_J2_plasticity.cpp
+++ b/src/constitutive/mechanical/plane/small_strain_J2_plasticity.cpp
@@ -34,16 +34,12 @@ void small_strain_J2_plasticity::update_internal_variables(double const time_ste
     auto const shear_modulus = material.shear_modulus();
 
     // Extract the internal variables
-    auto [plastic_strains,
-          strains,
-          cauchy_stresses] = variables->get(variable::second::linearised_plastic_strain,
-                                            variable::second::linearised_strain,
-                                            variable::second::cauchy_stress);
+    auto& plastic_strains = variables->get(variable::second::linearised_plastic_strain);
+    auto& strains = variables->get(variable::second::linearised_strain);
+    auto& accumulated_plastic_strains = variables->get(variable::scalar::effective_plastic_strain);
 
-    // Retrieve the accumulated internal variables
-    auto [accumulated_plastic_strains,
-          von_mises_stresses] = variables->get(variable::scalar::effective_plastic_strain,
-                                               variable::scalar::von_mises_stress);
+    auto& cauchy_stresses = variables->get(variable::second::cauchy_stress);
+    auto& von_mises_stresses = variables->get(variable::scalar::von_mises_stress);
 
     auto& tangent_operators = variables->get(variable::fourth::tangent_operator);
 

--- a/src/constitutive/mechanical/solid/affine_microsphere.hpp
+++ b/src/constitutive/mechanical/solid/affine_microsphere.hpp
@@ -33,17 +33,16 @@ public:
                                 json const& material_data,
                                 unit_sphere_quadrature::point const p);
 
-    virtual void update_internal_variables(double const time_step_size) override;
+    virtual ~affine_microsphere() = default;
 
-    [[nodiscard]] virtual material_property const& intrinsic_material() const noexcept override final
+    void update_internal_variables(double const time_step_size) override;
+
+    [[nodiscard]] material_property const& intrinsic_material() const noexcept override final
     {
         return material;
     }
 
-    [[nodiscard]] virtual bool is_finite_deformation() const noexcept override final
-    {
-        return true;
-    }
+    [[nodiscard]] bool is_finite_deformation() const noexcept override final { return true; }
 
 protected:
     /**

--- a/src/constitutive/mechanical/solid/compressible_neohooke.hpp
+++ b/src/constitutive/mechanical/solid/compressible_neohooke.hpp
@@ -25,23 +25,22 @@ namespace neon::mechanical::solid
 class compressible_neohooke : public constitutive_model
 {
 public:
-    /**
-     * @param variables Reference to internal state variable store
-     * @param material_data Json object with material data
-     */
+    /// \param variables Reference to internal state variable store
+    /// \param material_data Json object with material data
     explicit compressible_neohooke(std::shared_ptr<internal_variables_t>& variables,
                                    json const& material_data);
 
-    ~compressible_neohooke() = default;
+    virtual ~compressible_neohooke() = default;
 
-    virtual void update_internal_variables(double const time_step_size) override final;
+    void update_internal_variables(double const time_step_size) override final;
 
-    virtual material_property const& intrinsic_material() const override final { return material; };
+    material_property const& intrinsic_material() const override final { return material; };
 
-    virtual bool is_finite_deformation() const override final { return true; };
+    bool is_finite_deformation() const override final { return true; };
 
 private:
-    isotropic_elastic_property material; //!< Elastic model where C1 = mu/2 and C2 = bulk-modulus / 2
+    /// Elastic model where C1 = mu/2 and C2 = bulk-modulus / 2
+    isotropic_elastic_property material;
 };
 /** \} */
 }

--- a/src/constitutive/mechanical/solid/gaussian_affine_microsphere.hpp
+++ b/src/constitutive/mechanical/solid/gaussian_affine_microsphere.hpp
@@ -30,14 +30,13 @@ public:
                                          json const& material_data,
                                          unit_sphere_quadrature::point const p);
 
+    virtual ~gaussian_affine_microsphere() = default;
+
     virtual void update_internal_variables(double const time_step_size) override;
 
-    [[nodiscard]] virtual material_property const& intrinsic_material() const override final
-    {
-        return material;
-    }
+    material_property const& intrinsic_material() const override final { return material; }
 
-    [[nodiscard]] virtual bool is_finite_deformation() const override final { return true; }
+    bool is_finite_deformation() const override final { return true; }
 
 protected:
     /**

--- a/src/constitutive/mechanical/solid/gaussian_ageing_affine_microsphere.cpp
+++ b/src/constitutive/mechanical/solid/gaussian_ageing_affine_microsphere.cpp
@@ -80,34 +80,29 @@ gaussian_ageing_affine_microsphere::gaussian_ageing_affine_microsphere(
 
 void gaussian_ageing_affine_microsphere::update_internal_variables(double const time_step_size)
 {
-    auto [active_shear_modulus,
-          inactive_shear_modulus,
-          reduction_factor,
-          active_segments,
-          inactive_segments] = variables->get(variable::scalar::active_shear_modulus,
-                                              variable::scalar::inactive_shear_modulus,
-                                              variable::scalar::reduction_factor,
-                                              variable::scalar::active_segments,
-                                              variable::scalar::inactive_segments);
+    // Polymer network values
+    auto& active_shear_modulus = variables->get(variable::scalar::active_shear_modulus);
+    auto& inactive_shear_modulus = variables->get(variable::scalar::inactive_shear_modulus);
+    auto& reduction_factor = variables->get(variable::scalar::reduction_factor);
+    auto& active_segments = variables->get(variable::scalar::active_segments);
+    auto& inactive_segments = variables->get(variable::scalar::inactive_segments);
 
     // accumulated integral values from time integration
-    auto [moduli1,
-          moduli2,
-          moduli3] = variables->get(variable::vector::first_ageing_moduli,
-                                    variable::vector::second_ageing_moduli,
-                                    variable::vector::third_ageing_moduli);
+    auto& moduli1 = variables->get(variable::vector::first_ageing_moduli);
+    auto& moduli2 = variables->get(variable::vector::second_ageing_moduli);
+    auto& moduli3 = variables->get(variable::vector::third_ageing_moduli);
 
-    auto [sphere1, sphere2, sphere3] = variables->get(variable::vector::first_previous,
-                                                      variable::vector::second_previous,
-                                                      variable::vector::third_previous);
+    auto& sphere1 = variables->get(variable::vector::first_previous);
+    auto& sphere2 = variables->get(variable::vector::second_previous);
+    auto& sphere3 = variables->get(variable::vector::third_previous);
 
-    auto& moduli1_old = variables->get_old(variable::vector::first_ageing_moduli);
-    auto& moduli2_old = variables->get_old(variable::vector::second_ageing_moduli);
-    auto& moduli3_old = variables->get_old(variable::vector::third_ageing_moduli);
+    auto const& moduli1_old = variables->get_old(variable::vector::first_ageing_moduli);
+    auto const& moduli2_old = variables->get_old(variable::vector::second_ageing_moduli);
+    auto const& moduli3_old = variables->get_old(variable::vector::third_ageing_moduli);
 
-    auto& sphere1_old = variables->get_old(variable::vector::first_previous);
-    auto& sphere2_old = variables->get_old(variable::vector::second_previous);
-    auto& sphere3_old = variables->get_old(variable::vector::third_previous);
+    auto const& sphere1_old = variables->get_old(variable::vector::first_previous);
+    auto const& sphere2_old = variables->get_old(variable::vector::second_previous);
+    auto const& sphere3_old = variables->get_old(variable::vector::third_previous);
 
     auto& cauchy_stresses = variables->get(variable::second::cauchy_stress);
 

--- a/src/constitutive/mechanical/solid/gaussian_ageing_affine_microsphere.hpp
+++ b/src/constitutive/mechanical/solid/gaussian_ageing_affine_microsphere.hpp
@@ -31,6 +31,8 @@ public:
                                                 json const& material_data,
                                                 unit_sphere_quadrature::point const rule);
 
+    virtual ~gaussian_ageing_affine_microsphere() = default;
+
     virtual void update_internal_variables(double const time_step_size) override;
 
 private:

--- a/src/constitutive/mechanical/solid/small_strain_J2_plasticity.cpp
+++ b/src/constitutive/mechanical/solid/small_strain_J2_plasticity.cpp
@@ -30,16 +30,12 @@ void small_strain_J2_plasticity::update_internal_variables(double const time_ste
     auto const shear_modulus = material.shear_modulus();
 
     // Extract the internal variables
-    auto [plastic_strains,
-          strains,
-          cauchy_stresses] = variables->get(variable::second::linearised_plastic_strain,
-                                            variable::second::linearised_strain,
-                                            variable::second::cauchy_stress);
+    auto& plastic_strains = variables->get(variable::second::linearised_plastic_strain);
+    auto& strains = variables->get(variable::second::linearised_strain);
+    auto& accumulated_plastic_strains = variables->get(variable::scalar::effective_plastic_strain);
 
-    // Retrieve the accumulated internal variables
-    auto [accumulated_plastic_strains,
-          von_mises_stresses] = variables->get(variable::scalar::effective_plastic_strain,
-                                               variable::scalar::von_mises_stress);
+    auto& cauchy_stresses = variables->get(variable::second::cauchy_stress);
+    auto& von_mises_stresses = variables->get(variable::scalar::von_mises_stress);
 
     auto& tangent_operators = variables->get(variable::fourth::tangent_operator);
 

--- a/src/constitutive/mechanical/solid/small_strain_J2_plasticity_damage.cpp
+++ b/src/constitutive/mechanical/solid/small_strain_J2_plasticity_damage.cpp
@@ -34,24 +34,17 @@ small_strain_J2_plasticity_damage::~small_strain_J2_plasticity_damage() = defaul
 void small_strain_J2_plasticity_damage::update_internal_variables(double const time_step_size)
 {
     // Retrieve the internal variables
-    auto [plastic_strains,
-          strains,
-          cauchy_stresses,
-          back_stresses,
-          accumulated_kinematic_stresses] = variables->get(variable::second::linearised_plastic_strain,
-                                                           variable::second::linearised_strain,
-                                                           variable::second::cauchy_stress,
-                                                           variable::second::back_stress,
-                                                           variable::second::kinematic_hardening);
+    auto& plastic_strains = variables->get(variable::second::linearised_plastic_strain);
+    auto& strains = variables->get(variable::second::linearised_strain);
+    auto& accumulated_plastic_strains = variables->get(variable::scalar::effective_plastic_strain);
+    auto& accumulated_kinematic_stresses = variables->get(variable::second::kinematic_hardening);
 
-    // Retrieve the accumulated internal variables
-    auto [accumulated_plastic_strains,
-          von_mises_stresses,
-          scalar_damages,
-          energy_release_rates] = variables->get(variable::scalar::effective_plastic_strain,
-                                                 variable::scalar::von_mises_stress,
-                                                 variable::scalar::damage,
-                                                 variable::scalar::energy_release_rate);
+    auto& cauchy_stresses = variables->get(variable::second::cauchy_stress);
+    auto& back_stresses = variables->get(variable::second::back_stress);
+    auto& von_mises_stresses = variables->get(variable::scalar::von_mises_stress);
+
+    auto& energy_release_rates = variables->get(variable::scalar::energy_release_rate);
+    auto& scalar_damages = variables->get(variable::scalar::damage);
 
     auto& tangent_operators = variables->get(variable::fourth::tangent_operator);
 

--- a/src/interpolations/hermite.hpp
+++ b/src/interpolations/hermite.hpp
@@ -11,7 +11,7 @@ class hermite : public line_interpolation
 public:
     hermite(line_quadrature::point const p);
 
-    virtual int nodes() const override final { return 2; }
+    int nodes() const override final { return 2; }
 
     /// \return element length
     double compute_measure(matrix const& nodal_coordinates) const;

--- a/src/interpolations/hexahedron.hpp
+++ b/src/interpolations/hexahedron.hpp
@@ -14,7 +14,9 @@ class hexahedron8 : public volume_interpolation
 public:
     explicit hexahedron8(hexahedron_quadrature::point const p);
 
-    virtual int nodes() const override final { return 8; }
+    virtual ~hexahedron8() = default;
+
+    int nodes() const override final { return 8; }
 
     /// \return The element volume
     double compute_measure(matrix const& nodal_coordinates) const;
@@ -44,6 +46,8 @@ class hexahedron20 : public volume_interpolation
 public:
     explicit hexahedron20(hexahedron_quadrature::point const p);
 
+    virtual ~hexahedron20() = default;
+
     int nodes() const override final { return 20; }
 
     /// \return The element volume
@@ -60,6 +64,8 @@ class hexahedron27 : public volume_interpolation
 {
 public:
     explicit hexahedron27(hexahedron_quadrature::point const p);
+
+    virtual ~hexahedron27() = default;
 
     int nodes() const override final { return 27; }
 

--- a/src/interpolations/line.hpp
+++ b/src/interpolations/line.hpp
@@ -10,9 +10,11 @@ namespace neon
 class line2 : public line_interpolation
 {
 public:
-    line2(line_quadrature::point const p);
+    explicit line2(line_quadrature::point const p);
 
-    virtual int nodes() const override final { return 2; }
+    virtual ~line2() = default;
+
+    int nodes() const override final { return 2; }
 
     /// \return Element length
     double compute_measure(matrix const& nodal_coordinates) const;
@@ -32,9 +34,11 @@ protected:
 class line3 : public line_interpolation
 {
 public:
-    line3(line_quadrature::point const p);
+    explicit line3(line_quadrature::point const p);
 
-    virtual int nodes() const override final { return 3; }
+    virtual ~line3() = default;
+
+    int nodes() const override final { return 3; }
 
     /// \return Element length
     double compute_measure(matrix const& nodal_coordinates) const;

--- a/src/interpolations/prism.hpp
+++ b/src/interpolations/prism.hpp
@@ -15,7 +15,9 @@ class prism6 : public volume_interpolation
 public:
     explicit prism6(prism_quadrature::point const p);
 
-    virtual int nodes() const override final { return 6; }
+    virtual ~prism6() = default;
+
+    int nodes() const override final { return 6; }
 
     double compute_measure(matrix3x const& nodal_coordinates) const;
 
@@ -43,7 +45,9 @@ class prism15 : public volume_interpolation
 public:
     explicit prism15(prism_quadrature::point const p);
 
-    virtual int nodes() const override final { return 15; }
+    virtual ~prism15() = default;
+
+    int nodes() const override final { return 15; }
 
     double compute_measure(matrix3x const& nodal_coordinates) const;
 

--- a/src/interpolations/quadrilateral.hpp
+++ b/src/interpolations/quadrilateral.hpp
@@ -6,13 +6,15 @@
 
 namespace neon
 {
-/** A finite element with 4 nodal points and an isoparametric formulation */
+/// A finite element with 4 nodal points and an isoparametric formulation
 class quadrilateral4 : public surface_interpolation
 {
 public:
-    quadrilateral4(quadrilateral_quadrature::point const p);
+    explicit quadrilateral4(quadrilateral_quadrature::point const p);
 
-    virtual int nodes() const override final { return 4; }
+    virtual ~quadrilateral4() = default;
+
+    int nodes() const override final { return 4; }
 
     [[nodiscard]] double compute_measure(matrix const& nodal_coordinates) const;
 
@@ -31,11 +33,13 @@ protected:
     void precompute_shape_functions();
 };
 
-/** A finite element with 8 nodal points and an isoparametric formulation */
+/// A finite element with 8 nodal points and an isoparametric formulation
 class quadrilateral8 : public surface_interpolation
 {
 public:
-    quadrilateral8(quadrilateral_quadrature::point const p);
+    explicit quadrilateral8(quadrilateral_quadrature::point const p);
+
+    virtual ~quadrilateral8() = default;
 
     int nodes() const override final { return 8; }
 
@@ -45,11 +49,13 @@ protected:
     void precompute_shape_functions();
 };
 
-/** A finite element with 8 nodal points and an isoparametric formulation */
+/// A finite element with 8 nodal points and an isoparametric formulation
 class quadrilateral9 : public surface_interpolation
 {
 public:
-    quadrilateral9(quadrilateral_quadrature::point const p);
+    explicit quadrilateral9(quadrilateral_quadrature::point const p);
+
+    virtual ~quadrilateral9() = default;
 
     int nodes() const override final { return 9; }
 

--- a/src/interpolations/shape_function.hpp
+++ b/src/interpolations/shape_function.hpp
@@ -25,6 +25,8 @@ public:
     {
     }
 
+    virtual ~shape_function() = default;
+
     /// \return Number of nodes in the interpolation function
     virtual int nodes() const = 0;
 
@@ -49,8 +51,9 @@ protected:
 };
 
 template <typename quadrature_t>
-void shape_function<quadrature_t>::compute_extrapolation_matrix(
-    matrix const N, matrix const local_nodal_coordinates, matrix const local_quadrature_coordinates)
+void shape_function<quadrature_t>::compute_extrapolation_matrix(matrix const N,
+                                                                matrix const local_nodal_coordinates,
+                                                                matrix const local_quadrature_coordinates)
 {
     // Take short names for consistency with algorithm
 

--- a/src/interpolations/tetrahedron.hpp
+++ b/src/interpolations/tetrahedron.hpp
@@ -10,9 +10,11 @@ namespace neon
 class tetrahedron4 : public volume_interpolation
 {
 public:
-    tetrahedron4(tetrahedron_quadrature::point const p = tetrahedron_quadrature::point::one);
+    explicit tetrahedron4(tetrahedron_quadrature::point const p = tetrahedron_quadrature::point::one);
 
-    virtual int nodes() const override final { return 4; }
+    virtual ~tetrahedron4() = default;
+
+    int nodes() const override final { return 4; }
 
 protected:
     /**
@@ -32,9 +34,11 @@ protected:
 class tetrahedron10 : public volume_interpolation
 {
 public:
-    tetrahedron10(tetrahedron_quadrature::point const p);
+    explicit tetrahedron10(tetrahedron_quadrature::point const p);
 
-    virtual int nodes() const override final { return 10; }
+    virtual ~tetrahedron10() = default;
+
+    int nodes() const override final { return 10; }
 
 protected:
     /**

--- a/src/interpolations/triangle.hpp
+++ b/src/interpolations/triangle.hpp
@@ -12,7 +12,7 @@ class triangle3 : public surface_interpolation
 public:
     triangle3(triangle_quadrature::point const p);
 
-    virtual int nodes() const override final { return 3; }
+    int nodes() const override final { return 3; }
 
     double compute_measure(matrix const& nodal_coordinates) const;
 
@@ -33,7 +33,7 @@ class triangle6 : public surface_interpolation
 public:
     triangle6(triangle_quadrature::point const p);
 
-    virtual int nodes() const override final { return 6; }
+    int nodes() const override final { return 6; }
 
     /**
      * Compute the area of the element using Gaussian integration

--- a/src/mesh/boundary/neumann.hpp
+++ b/src/mesh/boundary/neumann.hpp
@@ -86,6 +86,11 @@ public:
     {
     }
 
+    virtual ~surface_load() = default;
+
+    surface_load(surface_load&& other) = default;
+    surface_load& operator=(surface_load const&) = default;
+
     /// Compute the external force due to a neumann type boundary condition.
     /// This computes the following integral on a boundary element
     /// \param element Surface element to compute external force on
@@ -147,6 +152,11 @@ public:
           sf(std::move(sf))
     {
     }
+
+    virtual ~volume_load() = default;
+
+    volume_load(volume_load&& other) = default;
+    volume_load& operator=(volume_load const&) = default;
 
     virtual std::pair<index_view, vector> external_force(std::int64_t const element,
                                                          double const load_factor) const override

--- a/src/mesh/diffusion/boundary/newton_convection.hpp
+++ b/src/mesh/diffusion/boundary/newton_convection.hpp
@@ -23,14 +23,12 @@ namespace neon::diffusion::boundary
 class newton_convection : public surface_load<surface_interpolation>
 {
 public:
-    /**
-     * Construct the boundary condition
-     * @param sf A surface interpolation
-     * @param node_indices
-     * @param times A list of times and values
-     * @param heat_flux A list of heat fluxes
-     * @param external_temperature A list of heat transfer coefficients
-     */
+    /// Construct the boundary condition
+    /// \param sf A surface interpolation
+    /// \param node_indices
+    /// \param times A list of times and values
+    /// \param heat_flux A list of heat fluxes
+    /// \param external_temperature A list of heat transfer coefficients
     explicit newton_convection(std::unique_ptr<surface_interpolation>&& sf,
                                indices node_indices,
                                indices dof_indices,
@@ -39,12 +37,10 @@ public:
                                json const& heat_flux,
                                json const& heat_transfer_coefficient);
 
-    /**
-     * Compute the element stiffness matrix contributing to the mixed boundary condition
-       \f{align*}{
-         k_{ab} &= \int_{\Gamma} N_a \lambda N_b d\Gamma
-       \f}
-     */
+    /// Compute the element stiffness matrix contributing to the mixed boundary condition
+    ///   \f{align*}{
+    ///     k_{ab} &= \int_{\Gamma} N_a \lambda N_b d\Gamma
+    ///   \f}
     [[nodiscard]] std::pair<index_view, matrix> external_stiffness(std::int64_t const element,
                                                                    double const load_factor) const;
 

--- a/src/mesh/diffusion/boundary/surface_boundary.cpp
+++ b/src/mesh/diffusion/boundary/surface_boundary.cpp
@@ -13,7 +13,7 @@ boundary_mesh::boundary_mesh(std::shared_ptr<material_coordinates>& material_coo
                              json const& boundary,
                              json const& mesh_data)
 {
-    if (auto const& type = boundary["Type"].get<std::string>(); type == "HeatFlux")
+    if (std::string const& type = boundary["Type"]; type == "HeatFlux")
     {
         for (auto const& mesh : submeshes)
         {

--- a/src/mesh/diffusion/boundary/surface_boundary.hpp
+++ b/src/mesh/diffusion/boundary/surface_boundary.hpp
@@ -11,20 +11,17 @@ class basic_submesh;
 
 namespace diffusion
 {
-/**
- * heat_flux is a group of the same elements on the same boundary. These
- * elements are responsible for computing their elemental right hand side contributions
- * with the corresponding shape function.  These are required to be stored in a parent
- * container with the other groups from the collective boundary \sa SurfaceBoundary
- */
+/// heat_flux is a group of the same elements on the same boundary. These
+/// elements are responsible for computing their elemental right hand side contributions
+/// with the corresponding shape function.  These are required to be stored in a parent
+/// container with the other groups from the collective boundary \sa SurfaceBoundary
 using heat_flux = surface_load<surface_interpolation>;
 
 // using heat_generation = volume_load<volume_interpolation>;
 
-/* boundary_mesh contains the boundary conditions and meshes which contribute to
- * the external load vector.  This can include flux boundary conditions and Newton
- * convection type boundaries.  Each element group has an entry in the vector
- */
+/// boundary_mesh contains the boundary conditions and meshes which contribute to
+/// the external load vector.  This can include flux boundary conditions and Newton
+/// convection type boundaries.  Each element group has an entry in the vector
 class boundary_mesh
 {
 public:
@@ -33,10 +30,10 @@ public:
                            json const& boundary,
                            json const& mesh_data);
 
-    /** @return the boundaries which contribute only to the load vector */
+    /// \return the boundaries which contribute only to the load vector
     [[nodiscard]] auto const& load_interface() const { return load_boundaries; }
 
-    /** @return the boundaries which contribute to the stiffness and the load vector */
+    /// \return the boundaries which contribute to the stiffness and the load vector
     [[nodiscard]] auto const& stiffness_load_interface() const { return stiffness_load_boundaries; }
 
 protected:

--- a/src/mesh/mechanical/beam/boundary/nonfollower_load.cpp
+++ b/src/mesh/mechanical/beam/boundary/nonfollower_load.cpp
@@ -30,7 +30,7 @@ nonfollower_load_boundary::nonfollower_load_boundary(
                     std::transform(begin(node_indices),
                                    end(node_indices),
                                    begin(node_indices),
-                                   [&](auto const node) {
+                                   [&, dof_offset = std::ref(dof_offset)](auto const node) {
                                        return node * 6 + dof_offset + (type == "force" ? 0 : 3);
                                    });
 

--- a/src/mesh/mechanical/beam/fem_mesh.cpp
+++ b/src/mesh/mechanical/beam/fem_mesh.cpp
@@ -105,7 +105,7 @@ void fem_mesh::allocate_dirichlet_boundary(std::string const& boundary_type,
             std::transform(begin(boundary_dofs),
                            end(boundary_dofs),
                            begin(boundary_dofs),
-                           [&](auto const dof) {
+                           [&, dof_offset = std::ref(dof_offset)](auto const dof) {
                                return dof + dof_offset + (boundary_type == "displacement" ? 0 : 3);
                            });
 

--- a/src/mesh/mechanical/beam/fem_submesh.cpp
+++ b/src/mesh/mechanical/beam/fem_submesh.cpp
@@ -42,12 +42,12 @@ void fem_submesh::update_internal_variables(double const time_step_size)
         profile = std::make_unique<geometry::rectangular_bar>(1.0, 1.0);
     }
 
-    auto [A, As1, As2] = variables->get(variable::scalar::cross_sectional_area,
-                                        variable::scalar::shear_area_1,
-                                        variable::scalar::shear_area_2);
+    auto& A = variables->get(variable::scalar::cross_sectional_area);
+    auto& As1 = variables->get(variable::scalar::shear_area_1);
+    auto& As2 = variables->get(variable::scalar::shear_area_2);
 
-    auto [area_moment_1, area_moment_2] = variables->get(variable::scalar::second_moment_area_1,
-                                                         variable::scalar::second_moment_area_2);
+    auto& area_moment_1 = variables->get(variable::scalar::second_moment_area_1);
+    auto& area_moment_2 = variables->get(variable::scalar::second_moment_area_2);
 
     // Loop over all elements and quadrature points to compute the profile
     // properties for each quadrature point in the beam

--- a/src/mesh/mechanical/plane/fem_mesh.cpp
+++ b/src/mesh/mechanical/plane/fem_mesh.cpp
@@ -127,7 +127,9 @@ void fem_mesh::allocate_displacement_boundary(json const& boundary, basic_mesh c
             std::transform(begin(boundary_dofs),
                            end(boundary_dofs),
                            begin(boundary_dofs),
-                           [&](auto const dof) { return dof + dof_offset; });
+                           [&, dof_offset = std::ref(dof_offset)](auto const dof) {
+                               return dof + dof_offset;
+                           });
 
             displacement_bcs[boundary_name].emplace_back(boundary_dofs,
                                                          boundary,

--- a/src/mesh/mechanical/solid/boundary/nonfollower_load.cpp
+++ b/src/mesh/mechanical/solid/boundary/nonfollower_load.cpp
@@ -99,7 +99,9 @@ nonfollower_load_boundary::nonfollower_load_boundary(
                     std::transform(begin(node_indices),
                                    end(node_indices),
                                    begin(node_indices),
-                                   [&](auto const node) { return node * 3 + dof_offset; });
+                                   [&, dof_offset = std::ref(dof_offset)](auto const node) {
+                                       return node * 3 + dof_offset;
+                                   });
 
                     nodal_values.emplace_back(node_indices, boundary_data, dof_name, generate_time_step);
                 }

--- a/src/mesh/mechanical/solid/fem_mesh.cpp
+++ b/src/mesh/mechanical/solid/fem_mesh.cpp
@@ -121,7 +121,9 @@ void fem_mesh::allocate_displacement_boundary(json const& boundary, basic_mesh c
             std::transform(begin(boundary_dofs),
                            end(boundary_dofs),
                            begin(boundary_dofs),
-                           [&](auto const dof) { return dof + dof_offset; });
+                           [&, dof_offset = std::ref(dof_offset)](auto const dof) {
+                               return dof + dof_offset;
+                           });
 
             displacement_bcs[boundary_name].emplace_back(boundary_dofs,
                                                          boundary,


### PR DESCRIPTION
Fix all the errors associated with slightly incorrect C++ to avoid compiler errors with clang.  Opens the road for #43.