### PR TITLE
Refactor of profile property calculations and testing

### DIFF
--- a/src/geometry/profile.cpp
+++ b/src/geometry/profile.cpp
@@ -56,7 +56,7 @@ circle::circle(json const& section_data)
                                 "section");
     }
 
-    auto constexpr pi = std::acos(-1.0);
+    auto const pi = std::acos(-1.0);
 
     I_x = I_y = pi * std::pow(diameter, 4) / 64.0;
     A = A_x = A_y = pi * std::pow(diameter, 2) / 4.0;

--- a/src/geometry/profile.cpp
+++ b/src/geometry/profile.cpp
@@ -1,34 +1,74 @@
 
 #include "profile.hpp"
+#include "io/json.hpp"
 
 namespace neon::geometry
 {
-profile::profile(double const I_1, double const I_2, double const A, double const A_1, double const A_2)
-    : I_1{I_1}, I_2{I_2}, m_area{A}, A_1{A_1}, A_2{A_2}
+std::pair<double, double> profile::second_moment_area() const noexcept { return {I_x, I_y}; }
+
+std::pair<double, double> profile::shear_area() const noexcept { return {A_x, A_y}; }
+
+double profile::area() const noexcept { return A; }
+
+rectangle::rectangle(json const& section_data)
 {
+    if (section_data.find("width") == section_data.end())
+    {
+        throw std::domain_error("\"width\" was not specified for \"rectangle\" in section");
+    }
+    if (section_data.find("height") == section_data.end())
+    {
+        throw std::domain_error("\"height\" was not specified for \"rectangle\" in section");
+    }
+    double const width = section_data["width"];
+
+    double const height = section_data["height"];
+
+    if (width <= 0.0)
+    {
+        throw std::domain_error("\"width\" must have a positive value for \"rectangle\" in "
+                                "section");
+    }
+
+    if (height <= 0.0)
+    {
+        throw std::domain_error("\"height\" must have a positive value for \"rectangle\" in "
+                                "section");
+    }
+
+    I_x = width * std::pow(height, 3) / 12.0;
+    I_y = std::pow(width, 3) * height / 12.0;
+    A = A_x = A_y = width * height;
 }
 
-std::pair<double, double> profile::second_moment_area() const noexcept { return {I_1, I_2}; }
-
-std::pair<double, double> profile::shear_area() const noexcept { return {A_1, A_2}; }
-
-double profile::area() const noexcept { return m_area; }
-
-rectangular_bar::rectangular_bar(double const width, double const height)
-    : profile(width * std::pow(height, 3) / 12.0,
-              std::pow(width, 3) * height / 12.0,
-              width * height,
-              width * height,
-              width * height)
+circle::circle(json const& section_data)
 {
+    if (section_data.find("diameter") == section_data.end())
+    {
+        throw std::domain_error("\"diameter\" was not specified for \"circle\" in section");
+    }
+
+    double const diameter = section_data["diameter"];
+
+    if (diameter <= 0.0)
+    {
+        throw std::domain_error("\"diameter\" must have a positive value for \"circle\" in "
+                                "section");
+    }
+
+    auto constexpr pi = std::acos(-1.0);
+
+    I_x = I_y = pi * std::pow(diameter, 4) / 64.0;
+    A = A_x = A_y = pi * std::pow(diameter, 2) / 4.0;
+    J = I_x * 2.0;
 }
 
-hollow_rectangular_bar::hollow_rectangular_bar(double const width, double const height)
-    : profile(width * std::pow(height, 3) / 12.0,
-              std::pow(width, 3) * height / 12.0,
-              width * height,
-              width * height,
-              width * height)
-{
-}
+// hollow_rectangle::hollow_rectangle(double const width, double const height)
+//     : profile(width * std::pow(height, 3) / 12.0,
+//               std::pow(width, 3) * height / 12.0,
+//               width * height,
+//               width * height,
+//               width * height)
+// {
+// }
 }

--- a/src/geometry/profile.hpp
+++ b/src/geometry/profile.hpp
@@ -1,6 +1,8 @@
 
 #pragma once
 
+#include "io/json_forward.hpp"
+
 #include <cmath>
 #include <utility>
 
@@ -12,18 +14,6 @@ namespace neon::geometry
 class profile
 {
 public:
-    /// Construct using base parameters
-    /// \param I_1 Second moment of area (1)
-    /// \param I_2 Second moment of area (2)
-    /// \param A Cross-sectional area
-    /// \param A_1 Shear area (1)
-    /// \param A_2 Shear area (2)
-    explicit profile(double const I_1,
-                     double const I_2,
-                     double const A,
-                     double const A_1,
-                     double const A_2);
-
     std::pair<double, double> second_moment_area() const noexcept;
 
     /// \return First and second shear area
@@ -34,34 +24,45 @@ public:
 
 protected:
     /// Area moment of inertia (first coordinate)
-    double I_1;
+    double I_x{0.0};
     /// Area moment of inertia (second coordinate)
-    double I_2;
+    double I_y{0.0};
+    /// Mixed moment of area about first and second coordinate
+    double I_xy{0.0};
 
     /// Section area
-    double m_area;
+    double A{0.0};
 
     /// Shear area (first coordinate)
-    double A_1;
-    /// Shear area (first coordinate)
-    double A_2;
+    double A_x{0.0};
+    /// Shear area (second coordinate)
+    double A_y{0.0};
+
+    /// Rotational polar moment of Area
+    double J{0.0};
 };
 
-/// rectangular_bar computes the second moment of area for a rectangular bar
-/// where a width and a height is specified.
-class rectangular_bar : public profile
+/// rectangle computes the second moment of area for a rectangular bar
+/// for a specified width and height.
+class rectangle : public profile
 {
 public:
-    explicit rectangular_bar(double const width, double const height);
+    explicit rectangle(json const& section_data);
 };
 
-/// hollow_rectangular_bar computes the second moment of area for a rectangular bar
+class circle : public profile
+{
+public:
+    explicit circle(json const& section_data);
+};
+
+/// hollow_rectangle computes the second moment of area for a rectangular bar
 /// with a hollow internal structure where a width and a height is specified.
-class hollow_rectangular_bar : public profile
-{
-public:
-    hollow_rectangular_bar(double const width, double const height);
-};
+// class hollow_rectangle : public profile
+// {
+// public:
+//     hollow_rectangle(double const width, double const height);
+// };
 
 class section
 {

--- a/src/geometry/profile.hpp
+++ b/src/geometry/profile.hpp
@@ -14,12 +14,13 @@ namespace neon::geometry
 class profile
 {
 public:
+    /// \return first and second moments of inertia (I_x, I_y)
     std::pair<double, double> second_moment_area() const noexcept;
 
-    /// \return First and second shear area
+    /// \return first and second shear areas (A_x, A_y)
     std::pair<double, double> shear_area() const noexcept;
 
-    /// \return Cross-section area
+    /// \return cross-section area
     double area() const noexcept;
 
 protected:

--- a/src/geometry/profile_factory.cpp
+++ b/src/geometry/profile_factory.cpp
@@ -6,19 +6,22 @@ namespace neon::geometry
 {
 std::unique_ptr<profile> make_profile(json const& profile_data)
 {
-    if (profile_data.count("Geometry") == 0)
+    if (profile_data.find("profile") == profile_data.end())
     {
-        throw std::domain_error("Please provide a \"Geometry\" section");
+        throw std::domain_error("Please provide a \"profile\" field");
     }
 
-    if (profile_data["Geometry"] == "Rectangle")
+    if (profile_data["profile"] == "rectangle")
     {
-        return std::make_unique<rectangular_bar>(1.0, 1.0);
+        return std::make_unique<rectangle>(profile_data);
     }
-    else if (profile_data["Geometry"] == "HollowRectangle")
+    else if (profile_data["profile"] == "circle")
     {
-        return std::make_unique<hollow_rectangular_bar>(1.0, 1.0);
+        return std::make_unique<circle>(profile_data);
     }
+
+    throw std::domain_error("A valid profile was not specified.  Valid profiles are \"rectangle\"");
+
     return nullptr;
 }
 }

--- a/src/mesh/mechanical/beam/fem_submesh.cpp
+++ b/src/mesh/mechanical/beam/fem_submesh.cpp
@@ -4,6 +4,7 @@
 #include "mesh/dof_allocator.hpp"
 #include "interpolations/interpolation_factory.hpp"
 #include "math/transform_expand.hpp"
+#include "geometry/profile_factory.hpp"
 
 #include <tbb/parallel_for.h>
 #include <Eigen/Geometry>
@@ -39,7 +40,8 @@ void fem_submesh::update_internal_variables(double const time_step_size)
 {
     for (auto& profile : profiles)
     {
-        profile = std::make_unique<geometry::rectangular_bar>(1.0, 1.0);
+        json profile_data{{"profile", "rectangle"}, {"width", 1.0}, {"height", 1.0}};
+        profile = geometry::make_profile(profile_data);
     }
 
     auto& A = variables->get(variable::scalar::cross_sectional_area);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ foreach(test
              constitutive
              dof_numbering
              gauss_quadrature
+             geometry_profile
              linear_beam_theory
              linear_solvers
              eigen_solvers

--- a/tests/geometry_profile.cpp
+++ b/tests/geometry_profile.cpp
@@ -1,0 +1,43 @@
+
+#include <catch.hpp>
+
+#include "geometry/profile_factory.hpp"
+#include "io/json.hpp"
+
+#include <stdexcept>
+
+using namespace neon;
+
+TEST_CASE("Geometry factory")
+{
+    SECTION("Name validation")
+    {
+        REQUIRE_THROWS_AS(make_profile(json::parse("{\"proile\": \"rectangle\"}")),
+                          std::domain_error);
+        REQUIRE_THROWS_AS(make_profile(json::parse("{\"profile\": \"rect\"}")), std::domain_error);
+    }
+}
+TEST_CASE("Dimensional values")
+{
+    SECTION("Rectangle")
+    {
+        json profile_data{{"profile", "rectangle"}, {"wdth", 2.0}, {"height", 0.3}};
+        REQUIRE_THROWS_AS(make_profile(profile_data), std::domain_error);
+
+        json profile_data{{"profile", "rectangle"}, {"width", 2.0}, {"hight", 0.3}};
+        REQUIRE_THROWS_AS(make_profile(profile_data), std::domain_error);
+
+        json profile_data{{"profile", "rectangle"}, {"width", -2.0}, {"height", 0.3}};
+        REQUIRE_THROWS_AS(make_profile(profile_data), std::domain_error);
+
+        json profile_data{{"profile", "rectangle"}, {"width", 2.0}, {"height", -0.3}};
+        REQUIRE_THROWS_AS(make_profile(profile_data), std::domain_error);
+    }
+    SECTION("Circle")
+    {
+        json profile_data{{"profile", "circle"}, {"dimeter", 2.0}};
+        REQUIRE_THROWS_AS(make_profile(profile_data), std::domain_error);
+
+        json profile_data{{"profile", "circle"}, {"diameter", -2.0}};
+        REQUIRE_THROWS_AS(make_profile(profile_data), std::domain_error);
+    }

--- a/tests/geometry_profile.cpp
+++ b/tests/geometry_profile.cpp
@@ -47,3 +47,60 @@ TEST_CASE("Dimensional values")
                           std::domain_error);
     }
 }
+
+TEST_CASE("Calculated values")
+{
+    SECTION("Square")
+    {
+        auto profile = geometry::make_profile(
+            json{{"profile", "rectangle"}, {"width", 1.0}, {"height", 1.0}});
+
+        REQUIRE(profile->area() == Approx(1.0));
+        REQUIRE(profile->second_moment_area().first == Approx(1.0 / 12.0));
+        REQUIRE(profile->second_moment_area().second == Approx(1.0 / 12.0));
+        REQUIRE(profile->shear_area().first == Approx(1.0));
+        REQUIRE(profile->shear_area().second == Approx(1.0));
+    }
+    SECTION("Horizontal rectangle")
+    {
+        auto profile = geometry::make_profile(
+            json{{"profile", "rectangle"}, {"width", 2.0}, {"height", 1.0}});
+
+        REQUIRE(profile->area() == Approx(2.0));
+        REQUIRE(profile->second_moment_area().first == Approx(1.0 / 6.0));
+        REQUIRE(profile->second_moment_area().second == Approx(2.0 / 3.0));
+        REQUIRE(profile->shear_area().first == Approx(2.0));
+        REQUIRE(profile->shear_area().second == Approx(2.0));
+    }
+    SECTION("Vertical rectangle")
+    {
+        auto profile = geometry::make_profile(
+            json{{"profile", "rectangle"}, {"width", 1.0}, {"height", 2.0}});
+
+        REQUIRE(profile->area() == Approx(2.0));
+        REQUIRE(profile->second_moment_area().first == Approx(2.0 / 3.0));
+        REQUIRE(profile->second_moment_area().second == Approx(1.0 / 6.0));
+        REQUIRE(profile->shear_area().first == Approx(2.0));
+        REQUIRE(profile->shear_area().second == Approx(2.0));
+    }
+    SECTION("Small circle")
+    {
+        auto profile = geometry::make_profile(json{{"profile", "circle"}, {"diameter", 1.0}});
+
+        REQUIRE(profile->area() == Approx(0.785398));
+        REQUIRE(profile->second_moment_area().first == Approx(0.049087));
+        REQUIRE(profile->second_moment_area().second == Approx(0.049087));
+        REQUIRE(profile->shear_area().first == Approx(0.785398));
+        REQUIRE(profile->shear_area().second == Approx(0.785398));
+    }
+    SECTION("Large circle")
+    {
+        auto profile = geometry::make_profile(json{{"profile", "circle"}, {"diameter", 2.0}});
+
+        REQUIRE(profile->area() == Approx(3.141593));
+        REQUIRE(profile->second_moment_area().first == Approx(0.785398));
+        REQUIRE(profile->second_moment_area().second == Approx(0.785398));
+        REQUIRE(profile->shear_area().first == Approx(3.141593));
+        REQUIRE(profile->shear_area().second == Approx(3.141593));
+    }
+}

--- a/tests/geometry_profile.cpp
+++ b/tests/geometry_profile.cpp
@@ -12,32 +12,38 @@ TEST_CASE("Geometry factory")
 {
     SECTION("Name validation")
     {
-        REQUIRE_THROWS_AS(make_profile(json::parse("{\"proile\": \"rectangle\"}")),
+        REQUIRE_THROWS_AS(geometry::make_profile(json::parse("{\"proile\": \"rectangle\"}")),
                           std::domain_error);
-        REQUIRE_THROWS_AS(make_profile(json::parse("{\"profile\": \"rect\"}")), std::domain_error);
+        REQUIRE_THROWS_AS(geometry::make_profile(json::parse("{\"profile\": \"rect\"}")),
+                          std::domain_error);
     }
 }
 TEST_CASE("Dimensional values")
 {
     SECTION("Rectangle")
     {
-        json profile_data{{"profile", "rectangle"}, {"wdth", 2.0}, {"height", 0.3}};
-        REQUIRE_THROWS_AS(make_profile(profile_data), std::domain_error);
+        REQUIRE_THROWS_AS(geometry::make_profile(
+                              json{{"profile", "rectangle"}, {"wdth", 2.0}, {"height", 0.3}}),
+                          std::domain_error);
 
-        json profile_data{{"profile", "rectangle"}, {"width", 2.0}, {"hight", 0.3}};
-        REQUIRE_THROWS_AS(make_profile(profile_data), std::domain_error);
+        REQUIRE_THROWS_AS(geometry::make_profile(
+                              json{{"profile", "rectangle"}, {"width", 2.0}, {"hight", 0.3}}),
+                          std::domain_error);
 
-        json profile_data{{"profile", "rectangle"}, {"width", -2.0}, {"height", 0.3}};
-        REQUIRE_THROWS_AS(make_profile(profile_data), std::domain_error);
+        REQUIRE_THROWS_AS(geometry::make_profile(
+                              json{{"profile", "rectangle"}, {"width", -2.0}, {"height", 0.3}}),
+                          std::domain_error);
 
-        json profile_data{{"profile", "rectangle"}, {"width", 2.0}, {"height", -0.3}};
-        REQUIRE_THROWS_AS(make_profile(profile_data), std::domain_error);
+        REQUIRE_THROWS_AS(geometry::make_profile(
+                              json{{"profile", "rectangle"}, {"width", 2.0}, {"height", -0.3}}),
+                          std::domain_error);
     }
     SECTION("Circle")
     {
-        json profile_data{{"profile", "circle"}, {"dimeter", 2.0}};
-        REQUIRE_THROWS_AS(make_profile(profile_data), std::domain_error);
+        REQUIRE_THROWS_AS(geometry::make_profile(json{{"profile", "circle"}, {"dimeter", 2.0}}),
+                          std::domain_error);
 
-        json profile_data{{"profile", "circle"}, {"diameter", -2.0}};
-        REQUIRE_THROWS_AS(make_profile(profile_data), std::domain_error);
+        REQUIRE_THROWS_AS(geometry::make_profile(json{{"profile", "circle"}, {"diameter", -2.0}}),
+                          std::domain_error);
     }
+}


### PR DESCRIPTION
Use of json input file data for profile property calculations rather than built-in data types.
Groundwork for rectangle and circle complete, other geometry profiles still to be implemented and tested.
Testing for failure due to invalid input for rectangle and circle complete.
