### PR TITLE
Thread local stiffness matrices

### DIFF
--- a/src/assembler/mechanics/static_matrix.hpp
+++ b/src/assembler/mechanics/static_matrix.hpp
@@ -254,7 +254,7 @@ void static_matrix<MeshType>::assemble_stiffness()
     for (auto const& submesh : fem_mesh.meshes())
     {
         tbb::parallel_for(std::int64_t{0}, submesh.elements(), [&](auto const element) {
-            auto const [dofs, ke] = submesh.tangent_stiffness(element);
+            auto const& [dofs, ke] = submesh.tangent_stiffness(element);
 
             for (std::int64_t b{0}; b < dofs.size(); b++)
             {

--- a/src/mesh/mechanics/solid/submesh.hpp
+++ b/src/mesh/mechanics/solid/submesh.hpp
@@ -53,10 +53,16 @@ public:
     [[nodiscard]] auto const& constitutive() const { return *cm; }
 
     /// \return tangent consistent stiffness matrix
-    [[nodiscard]] std::pair<index_view, matrix> tangent_stiffness(std::int32_t const element) const;
+    [[nodiscard]] std::pair<index_view, matrix const&> tangent_stiffness(std::int32_t const element) const;
 
-    /// \return internal element force
-    [[nodiscard]] std::pair<index_view, vector> internal_force(std::int32_t const element) const;
+    /**
+     * Compute the internal force vector using the formula
+     * \f{align*}{
+     * f_{int} &= \int_{V} B^{T} \sigma dV
+     * \f}
+     * \return internal element force
+     */
+    [[nodiscard]] std::pair<index_view, vector const&> internal_force(std::int32_t const element) const;
 
     /// \return consistent mass matrix \sa diagonal_mass
     [[nodiscard]] std::pair<index_view, matrix> consistent_mass(std::int32_t const element) const;
@@ -92,8 +98,8 @@ protected:
        \f}
      * Where B is the gradient operator in the finite element discretization
      */
-    [[nodiscard]] matrix geometric_tangent_stiffness(matrix3x const& configuration,
-                                                     std::int32_t const element) const;
+    [[nodiscard]] matrix const& geometric_tangent_stiffness(matrix3x const& configuration,
+                                                            std::int32_t const element) const;
 
     /**
      * Compute the material tangent stiffness using the formula
@@ -101,18 +107,8 @@ protected:
      * k_{mat} &= I_{2x2} \int_{V} B_I^{T} \sigma B_{J} dV
      * \f}
      */
-    [[nodiscard]] matrix material_tangent_stiffness(matrix3x const& configuration,
-                                                    std::int32_t const element) const;
-
-    /**
-     * Compute the internal force vector using the formula
-     * \f{align*}{
-     * f_{int} &= \int_{V} B^{T} \sigma dV
-     * \f}
-     * @return the internal nodal force vector
-     */
-    [[nodiscard]] vector internal_nodal_force(matrix3x const& configuration,
-                                              std::int32_t const element) const;
+    [[nodiscard]] matrix const& material_tangent_stiffness(matrix3x const& configuration,
+                                                           std::int32_t const element) const;
 
 private:
     std::shared_ptr<material_coordinates> coordinates;

--- a/src/numeric/tensor_operations.hpp
+++ b/src/numeric/tensor_operations.hpp
@@ -10,30 +10,29 @@ namespace neon
 {
 /// Performs the tensor dot product on two second order tensors in three dimensions.
 template <class MatrixLeft, class MatrixRight>
-[[nodiscard]] double double_dot(MatrixLeft const& a, MatrixRight const& b)
-{
+[[nodiscard]] double double_dot(MatrixLeft const& a, MatrixRight const& b) {
     return (a.array() * b.array()).sum();
 }
 
 namespace detail
 {
-/// \return the volumetric part of the tensor
-[[nodiscard]] inline matrix2 volumetric(matrix2 const& a)
-{
-    return matrix2::Identity() * a.trace() / 3.0;
-}
+    /// \return the volumetric part of the tensor
+    [[nodiscard]] inline matrix2 volumetric(matrix2 const& a)
+    {
+        return matrix2::Identity() * a.trace() / 3.0;
+    }
 
-/// \return the volumetric part of the tensor
-[[nodiscard]] inline matrix3 volumetric(matrix3 const& a)
-{
-    return matrix3::Identity() * a.trace() / 3.0;
-}
+    /// \return the volumetric part of the tensor
+    [[nodiscard]] inline matrix3 volumetric(matrix3 const& a)
+    {
+        return matrix3::Identity() * a.trace() / 3.0;
+    }
 
-/// \return the deviatoric part of the tensor
-[[nodiscard]] inline matrix2 deviatoric(matrix2 const& a) { return a - volumetric(a); }
+    /// \return the deviatoric part of the tensor
+    [[nodiscard]] inline matrix2 deviatoric(matrix2 const& a) { return a - volumetric(a); }
 
-/// \return the deviatoric part of the tensor
-[[nodiscard]] inline matrix3 deviatoric(matrix3 const& a) { return a - volumetric(a); }
+    /// \return the deviatoric part of the tensor
+    [[nodiscard]] inline matrix3 deviatoric(matrix3 const& a) { return a - volumetric(a); }
 }
 
 /// \return the volumetric part of the tensor
@@ -101,6 +100,22 @@ template <typename MatrixExpression>
             for (auto k = 0; k < nodal_dofs; ++k)
                 K(i * nodal_dofs + k, j * nodal_dofs + k) = H(i, j);
     return K;
+}
+
+template <int Dimension>
+inline void identity_expansion_inplace(matrix const& H_in, matrix& H_out) noexcept
+{
+    // Create the geometric part of the tangent stiffness matrix
+    for (auto i = 0; i < H_in.rows(); ++i)
+    {
+        for (auto j = 0; j < H_in.rows(); ++j)
+        {
+            for (auto k = 0; k < Dimension; ++k)
+            {
+                H_out(i * Dimension + k, j * Dimension + k) = H_in(i, j);
+            }
+        }
+    }
 }
 
 /**

--- a/src/numeric/tensor_operations.hpp
+++ b/src/numeric/tensor_operations.hpp
@@ -10,29 +10,30 @@ namespace neon
 {
 /// Performs the tensor dot product on two second order tensors in three dimensions.
 template <class MatrixLeft, class MatrixRight>
-[[nodiscard]] double double_dot(MatrixLeft const& a, MatrixRight const& b) {
+[[nodiscard]] double double_dot(MatrixLeft const& a, MatrixRight const& b)
+{
     return (a.array() * b.array()).sum();
 }
 
 namespace detail
 {
-    /// \return the volumetric part of the tensor
-    [[nodiscard]] inline matrix2 volumetric(matrix2 const& a)
-    {
-        return matrix2::Identity() * a.trace() / 3.0;
-    }
+/// \return the volumetric part of the tensor
+[[nodiscard]] inline matrix2 volumetric(matrix2 const& a)
+{
+    return matrix2::Identity() * a.trace() / 3.0;
+}
 
-    /// \return the volumetric part of the tensor
-    [[nodiscard]] inline matrix3 volumetric(matrix3 const& a)
-    {
-        return matrix3::Identity() * a.trace() / 3.0;
-    }
+/// \return the volumetric part of the tensor
+[[nodiscard]] inline matrix3 volumetric(matrix3 const& a)
+{
+    return matrix3::Identity() * a.trace() / 3.0;
+}
 
-    /// \return the deviatoric part of the tensor
-    [[nodiscard]] inline matrix2 deviatoric(matrix2 const& a) { return a - volumetric(a); }
+/// \return the deviatoric part of the tensor
+[[nodiscard]] inline matrix2 deviatoric(matrix2 const& a) { return a - volumetric(a); }
 
-    /// \return the deviatoric part of the tensor
-    [[nodiscard]] inline matrix3 deviatoric(matrix3 const& a) { return a - volumetric(a); }
+/// \return the deviatoric part of the tensor
+[[nodiscard]] inline matrix3 deviatoric(matrix3 const& a) { return a - volumetric(a); }
 }
 
 /// \return the volumetric part of the tensor


### PR DESCRIPTION
This work enables thread local storage for static function stiffness matrices.  By using thread local storage we avoid continual allocation and deletion of memory, resulting in hopefully less heap fragmentation over longer simulations with multiple threads.