### PR TITLE
approximate equality function

### DIFF
--- a/examples/solid_mechanics/hyperelastic/nonaffine_microsphere/specimen/specimen.json
+++ b/examples/solid_mechanics/hyperelastic/nonaffine_microsphere/specimen/specimen.json
@@ -19,7 +19,7 @@
         "nonlinear_options" : {
             "displacement_tolerance" : 1.0e-3,
             "residual_tolerance" : 1.0e-3,
-	          "newton_raphson_iterations" : 30
+	        "newton_raphson_iterations" : 30
         },
         "time" : {
             "period" : 1.0,

--- a/examples/solid_mechanics/hyperelastic/nonaffine_microsphere/specimen/specimen.json
+++ b/examples/solid_mechanics/hyperelastic/nonaffine_microsphere/specimen/specimen.json
@@ -18,7 +18,8 @@
         "solution" : "equilibrium",
         "nonlinear_options" : {
             "displacement_tolerance" : 1.0e-3,
-            "residual_tolerance" : 1.0e-3
+            "residual_tolerance" : 1.0e-3,
+	          "newton_raphson_iterations" : 30
         },
         "time" : {
             "period" : 1.0,

--- a/src/assembler/mechanics/static_matrix.hpp
+++ b/src/assembler/mechanics/static_matrix.hpp
@@ -382,14 +382,12 @@ void static_matrix<MeshType>::print_convergence_progress() const
 template <class MeshType>
 void static_matrix<MeshType>::update_relative_norms()
 {
-    if (use_relative_norm && !is_approx(displacement.norm(), 0.0))
+    if (use_relative_norm && !is_approx(displacement.norm(), 0.0, 1.0)
+        && !is_approx(std::max(f_ext.norm(), f_int.norm()), 0.0, 1.0))
     {
         displacement_norm = delta_d.norm() / displacement.norm();
-        force_norm = is_approx(std::max(f_ext.norm(), f_int.norm()), 0.0)
-                         ? 1.0
-                         : minus_residual.norm()
-                               / std::max(norm_initial_residual,
-                                          std::max(f_ext.norm(), f_int.norm()));
+        force_norm = minus_residual.norm()
+                     / std::max(norm_initial_residual, std::max(f_ext.norm(), f_int.norm()));
     }
     else
     {

--- a/src/numeric/float_compare.hpp
+++ b/src/numeric/float_compare.hpp
@@ -1,31 +1,32 @@
 
 #pragma once
 
-#include <cmath>
-#include <limits>
 #include <type_traits>
+
+#include <boost/math/special_functions/relative_difference.hpp>
 
 /// \file float_compare.hpp
 
 /// neon namespace
 namespace neon
 {
-/// Perform a floating point comparison using a specified number of units
-/// in the last place
+/// Perform a floating point comparison using boost for large numbers and an absolute error for smaller ones
+
 /// \tparam Floating point type
 /// \param x Value 1
 /// \param y Value 2
-/// \param ulp Number of units in last place
+/// \param absolute_tolerance
+/// \param relative_tolerance
 template <class T>
 std::enable_if_t<std::is_floating_point<T>::value, bool> is_approx(T const x,
                                                                    T const y,
-                                                                   int const ulp = 2) noexcept
+                                                                   T const absolute_tolerance = 0.0,
+                                                                   T const relative_tolerance = 1e-10) noexcept
 {
-    // Taken and modified from
-    // http://en.cppreference.com/w/cpp/types/numeric_limits/epsilon
-    // Since the numeric epsilon is defined at 1.0 then it must be scaled by
-    // the worse case (x + y) and accounted for by the ULP (units in the last place).
-    return std::abs(x - y) < std::numeric_limits<T>::epsilon() * std::abs(x + y) * ulp
-           || std::abs(x - y) < std::numeric_limits<T>::min();
+    // References:
+    // https://www.boost.org/doc/libs/1_67_0/libs/math/doc/html/math_toolkit/float_comparison.html
+    // https://www.python.org/dev/peps/pep-0485/
+    return boost::math::relative_difference(x, y) <= relative_tolerance
+           || std::abs(x - y) <= absolute_tolerance;
 }
 }


### PR DESCRIPTION
This PR modifies the approximate equality function to use `boost::math::relative_difference` from
[https://www.boost.org/doc/libs/1_67_0/libs/math/doc/html/math_toolkit/float_comparison.html](url)
in addition to an absolute tolerance similar to
[https://www.python.org/dev/peps/pep-0485/](url)
that can be used when comparing numbers close to zero.

In `static_matrix`, when the norm of the displacement or the forces is less than one, then no relative tolerance is used. What do you think?