### PR TITLE
change -ffast-math to less optimised options

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,7 +25,7 @@ if (ENABLE_NATIVE)
 endif()
 
 if (ENABLE_FAST_MATH)
-    target_compile_options(neon PUBLIC $<$<COMPILE_LANGUAGE:CXX>:-ffast-math>)
+    target_compile_options(neon PUBLIC $<$<COMPILE_LANGUAGE:CXX>:-fassociative-math -fno-signed-zeros -fno-trapping-math -fno-math-errno>)
 endif()
 
 if(ENABLE_COVERAGE)


### PR DESCRIPTION
This PR closes issue #126. `-ffast-math` is swapped with:
- `-fassociative-math`
Allow re-association of operands in series of floating-point operations. 
- `-fno-signed-zeros`
Allow optimizations for floating-point arithmetic that ignore the signedness of zero.
- `-fno-trapping-math`
Compile code assuming that floating-point operations cannot generate user-visible traps.
- `-fno-math-errno`
Do not set errno after calling math functions that are executed with a single instruction, e.g., sqrt.

In this case all tests still pass even the ones checking for infs or nans