### PR TITLE
Rectangular angle profile and compilation bug fix

### DIFF
--- a/src/geometry/profile.cpp
+++ b/src/geometry/profile.cpp
@@ -112,4 +112,65 @@ hollow_circle::hollow_circle(json const& section_data)
 //               width * height)
 // {
 // }
+
+rectangular_angle::rectangular_angle(json const& section_data)
+{
+    if (section_data.find("width") == section_data.end())
+    {
+        throw std::domain_error("\"width\" was not specified for \"rectangular_angle\" in profile");
+    }
+    if (section_data.find("height") == section_data.end())
+    {
+        throw std::domain_error("\"height\" was not specified for \"rectangular_angle\" in "
+                                "profile");
+    }
+    if (section_data.find("thickness") == section_data.end())
+    {
+        throw std::domain_error("\"thickness\" was not specified for \"rectangular_angle\" in "
+                                "profile");
+    }
+
+    double const width = section_data["width"];
+
+    double const height = section_data["height"];
+
+    double const thickness = section_data["thickness"];
+
+    if (width <= 0.0)
+    {
+        throw std::domain_error("\"width\" must have a positive value for \"rectangular_angle\" in "
+                                "profile");
+    }
+
+    if (height <= 0.0)
+    {
+        throw std::domain_error("\"height\" must have a positive value for \"rectangular_angle\" "
+                                "in "
+                                "profile");
+    }
+
+    if (thickness <= 0.0)
+    {
+        throw std::domain_error("\"thickness\" must have a positive value for "
+                                "\"rectangular_angle\" in "
+                                "profile");
+    }
+
+    // Formulas sourced from: http://structx.com/Shape_Formulas_008.html
+    double const c = width - thickness;
+    double const d = height - thickness;
+    double const C_x = (thickness * (2 * c + height) + std::pow(c, 2)) / (2 * (c + height));
+    double const C_y = (thickness * (2 * d + width) + std::pow(d, 2)) / (2 * (d + width));
+    double const y = height - C_y;
+    double const z = width - C_x;
+    I_x = (thickness * std::pow(y, 3) + width * std::pow(height - y, 3)
+           - (width - thickness) * std::pow(height - y - thickness, 3))
+          / 3.0;
+
+    I_y = (thickness * std::pow(z, 3) + height * std::pow(width - z, 3)
+           - (height - thickness) * std::pow(width - z - thickness, 3))
+          / 3.0;
+
+    A = thickness * (width + d);
+}
 }

--- a/src/geometry/profile.hpp
+++ b/src/geometry/profile.hpp
@@ -16,7 +16,8 @@ namespace neon::geometry
 class profile
 {
 public:
-    /// \return first and second moments of inertia (I_x, I_y)
+    /// \return first and second moments of area
+    /// (area moment of inertia) (I_x, I_y)
     std::pair<double, double> second_moment_area() const noexcept;
 
     /// \return first and second shear areas (A_x, A_y)
@@ -71,5 +72,10 @@ class hollow_circle : public profile
 {
 public:
     explicit hollow_circle(json const& section_data);
+};
+class rectangular_angle : public profile
+{
+public:
+    explicit rectangular_angle(json const& section_data);
 };
 }

--- a/src/geometry/profile.hpp
+++ b/src/geometry/profile.hpp
@@ -73,6 +73,7 @@ class hollow_circle : public profile
 public:
     explicit hollow_circle(json const& section_data);
 };
+
 class rectangular_angle : public profile
 {
 public:

--- a/src/geometry/profile_factory.cpp
+++ b/src/geometry/profile_factory.cpp
@@ -11,17 +11,21 @@ std::unique_ptr<profile> make_profile(json const& profile_data)
         throw std::domain_error("Please provide a \"type\" field");
     }
 
-    if (profile_data["type"] == "rectangle")
+    if (auto const& profile_type = profile_data["type"]; profile_type == "rectangle")
     {
         return std::make_unique<rectangle>(profile_data);
     }
-    else if (profile_data["type"] == "circle")
+    else if (profile_type == "circle")
     {
         return std::make_unique<circle>(profile_data);
     }
-    else if (profile_data["type"] == "hollow_circle")
+    else if (profile_type == "hollow_circle")
     {
         return std::make_unique<hollow_circle>(profile_data);
+    }
+    else if (profile_type == "rectangular_angle")
+    {
+        return std::make_unique<rectangular_angle>(profile_data);
     }
 
     throw std::domain_error("A valid profile type was not specified.  Valid profiles are "

--- a/src/solver/eigen/eigen_solver_factory.cpp
+++ b/src/solver/eigen/eigen_solver_factory.cpp
@@ -54,8 +54,8 @@ std::unique_ptr<eigen_solver> make_eigen_solver(json const& solver_data)
     if (std::string const& type = solver_data["type"]; type == "power_iteration")
     {
 #ifndef ENABLE_OPENCL
-        throw std::domain_error("The \"opencl\" option requires compiler support.  "
-                                "Recompile with -DENABLE_OPENCL=1.");
+        throw std::domain_error("The \"power_iteration\" option requires OpenCL support.  "
+                                "Recompile with -DENABLE_OPENCL=1");
 #else
         return std::make_unique<power_iteration>(number_of_ev, spectrum);
 #endif
@@ -63,8 +63,8 @@ std::unique_ptr<eigen_solver> make_eigen_solver(json const& solver_data)
     else if (type == "lanczos")
     {
 #ifndef ENABLE_OPENCL
-        throw std::domain_error("The \"opencl\" option requires compiler support.  "
-                                "Recompile with -DENABLE_OPENCL=1.");
+        throw std::domain_error("The \"lanczos\" option requires OpenCL support.  "
+                                "Recompile with -DENABLE_OPENCL=1");
 #else
         return std::make_unique<lanczos_ocl>(number_of_ev, spectrum);
 #endif

--- a/src/solver/eigen/eigen_solver_factory.cpp
+++ b/src/solver/eigen/eigen_solver_factory.cpp
@@ -53,11 +53,21 @@ std::unique_ptr<eigen_solver> make_eigen_solver(json const& solver_data)
 
     if (std::string const& type = solver_data["type"]; type == "power_iteration")
     {
+#ifndef ENABLE_OPENCL
+        throw std::domain_error("The \"opencl\" option requires compiler support.  "
+                                "Recompile with -DENABLE_OPENCL=1.");
+#else
         return std::make_unique<power_iteration>(number_of_ev, spectrum);
+#endif
     }
     else if (type == "lanczos")
     {
+#ifndef ENABLE_OPENCL
+        throw std::domain_error("The \"opencl\" option requires compiler support.  "
+                                "Recompile with -DENABLE_OPENCL=1.");
+#else
         return std::make_unique<lanczos_ocl>(number_of_ev, spectrum);
+#endif
     }
     else if (type == "arpack")
     {

--- a/src/solver/eigen/lanczos_ocl.cpp
+++ b/src/solver/eigen/lanczos_ocl.cpp
@@ -1,6 +1,8 @@
 
 #include "solver/eigen/lanczos_ocl.hpp"
 
+#ifdef ENABLE_OPENCL
+
 #define VIENNACL_HAVE_EIGEN
 
 #include <viennacl/compressed_matrix.hpp>
@@ -46,3 +48,4 @@ void lanczos_ocl::solve(sparse_matrix const& A)
 
 void lanczos_ocl::solve(sparse_matrix const&, sparse_matrix const&) {}
 }
+#endif

--- a/src/solver/eigen/lanczos_ocl.hpp
+++ b/src/solver/eigen/lanczos_ocl.hpp
@@ -3,6 +3,8 @@
 
 /// @file
 
+#ifdef ENABLE_OPENCL
+
 #include "solver/eigen/eigen_solver.hpp"
 
 namespace neon
@@ -23,3 +25,4 @@ public:
     virtual void solve(sparse_matrix const& A, sparse_matrix const& B) override final;
 };
 }
+#endif

--- a/src/solver/eigen/power_iteration.cpp
+++ b/src/solver/eigen/power_iteration.cpp
@@ -1,6 +1,8 @@
 
 #include "solver/eigen/power_iteration.hpp"
 
+#ifdef ENABLE_OPENCL
+
 #include "exceptions.hpp"
 
 #define VIENNACL_HAVE_EIGEN
@@ -45,3 +47,4 @@ void power_iteration::solve(sparse_matrix const&, sparse_matrix const&)
     throw std::runtime_error("Method not implemented " + std::string(__FUNCTION__));
 }
 }
+#endif

--- a/src/solver/eigen/power_iteration.hpp
+++ b/src/solver/eigen/power_iteration.hpp
@@ -3,6 +3,8 @@
 
 /// @file
 
+#ifdef ENABLE_OPENCL
+
 #include "solver/eigen/eigen_solver.hpp"
 
 namespace neon
@@ -21,3 +23,4 @@ public:
     virtual void solve(sparse_matrix const& A, sparse_matrix const& B) override final;
 };
 }
+#endif

--- a/test/eigenvalue_solvers.cpp
+++ b/test/eigenvalue_solvers.cpp
@@ -57,6 +57,7 @@ TEST_CASE("Arpack eigenvalues")
         REQUIRE(vectors.col(i).norm() == Approx(1.0));
     }
 }
+#ifdef ENABLE_OPENCL
 TEST_CASE("Power iteration eigenvalue")
 {
     neon::power_iteration solver{1};
@@ -91,3 +92,4 @@ TEST_CASE("Lanczos iteration eigenvalue")
         REQUIRE(vectors.col(i).norm() == Approx(1.0));
     }
 }
+#endif

--- a/test/geometry_profile.cpp
+++ b/test/geometry_profile.cpp
@@ -22,6 +22,7 @@ TEST_CASE("Dimensional values")
 {
     SECTION("Rectangle")
     {
+        // Spelling
         REQUIRE_THROWS_AS(geometry::make_profile(
                               json{{"type", "rectangle"}, {"wdth", 2.0}, {"height", 0.3}}),
                           std::domain_error);
@@ -30,6 +31,7 @@ TEST_CASE("Dimensional values")
                               json{{"type", "rectangle"}, {"width", 2.0}, {"hight", 0.3}}),
                           std::domain_error);
 
+        // Negative value
         REQUIRE_THROWS_AS(geometry::make_profile(
                               json{{"type", "rectangle"}, {"width", -2.0}, {"height", 0.3}}),
                           std::domain_error);
@@ -74,6 +76,41 @@ TEST_CASE("Dimensional values")
         REQUIRE_THROWS_AS(geometry::make_profile(json{{"type", "hollow_circle"},
                                                       {"inner_diameter", 2.0},
                                                       {"outer_diameter", 1.0}}),
+                          std::domain_error);
+    }
+    SECTION("Rectangular angle")
+    {
+        // Spelling
+        REQUIRE_THROWS_AS(geometry::make_profile(json{{"type", "rectangular_angle"},
+                                                      {"with", 1.0},
+                                                      {"height", 2.0},
+                                                      {"thickness", 0.5}}),
+                          std::domain_error);
+        REQUIRE_THROWS_AS(geometry::make_profile(json{{"type", "rectangular_angle"},
+                                                      {"width", 1.0},
+                                                      {"heigt", 2.0},
+                                                      {"thickness", 0.5}}),
+                          std::domain_error);
+        REQUIRE_THROWS_AS(geometry::make_profile(json{{"type", "rectangular_angle"},
+                                                      {"width", 1.0},
+                                                      {"height", 2.0},
+                                                      {"thickess", 0.5}}),
+                          std::domain_error);
+        // Negative value
+        REQUIRE_THROWS_AS(geometry::make_profile(json{{"type", "rectangular_angle"},
+                                                      {"width", -1.0},
+                                                      {"height", 2.0},
+                                                      {"thickess", 0.5}}),
+                          std::domain_error);
+        REQUIRE_THROWS_AS(geometry::make_profile(json{{"type", "rectangular_angle"},
+                                                      {"width", 1.0},
+                                                      {"height", -2.0},
+                                                      {"thickess", 0.5}}),
+                          std::domain_error);
+        REQUIRE_THROWS_AS(geometry::make_profile(json{{"type", "rectangular_angle"},
+                                                      {"width", 1.0},
+                                                      {"height", 2.0},
+                                                      {"thickess", -0.5}}),
                           std::domain_error);
     }
 }

--- a/test/geometry_profile.cpp
+++ b/test/geometry_profile.cpp
@@ -181,4 +181,21 @@ TEST_CASE("Calculated values")
         REQUIRE(profile->second_moment_area().first == Approx(0.736311));
         REQUIRE(profile->second_moment_area().second == Approx(0.736311));
     }
+    SECTION("Rectangular angle")
+    {
+        auto profile = geometry::make_profile(
+            json{{"type", "rectangular_angle"}, {"width", 1.0}, {"height", 2.0}, {"thickness", 0.5}});
+
+        REQUIRE(profile->area() == Approx(1.25));
+        REQUIRE(profile->second_moment_area().first == Approx(0.451042));
+        REQUIRE(profile->second_moment_area().second == Approx(0.076042));
+    }
+    {
+        auto profile = geometry::make_profile(
+            json{{"type", "rectangular_angle"}, {"width", 2.0}, {"height", 1.0}, {"thickness", 0.5}});
+
+        REQUIRE(profile->area() == Approx(1.25));
+        REQUIRE(profile->second_moment_area().first == Approx(0.076042));
+        REQUIRE(profile->second_moment_area().second == Approx(0.451042));
+    }
 }


### PR DESCRIPTION
This PR includes the addition of rectangular angle geometry profiles and testing.  Further geometry profiles and documentation are still needed before this section is complete.

As a side patch, the `ENABLE_OPENCL` preprocessor symbol was added around ViennaCL for the eigenvalue solvers in order to fix a compilation bug caused when a machine has no ViennaCL installation and has not enabled the `ENABLE_OPENCL` option, as discovered by using a different machine for compilation.

